### PR TITLE
Upgrade XXhash to XXH3 add wyhash

### DIFF
--- a/randstrobe_implementations/src/index.cpp
+++ b/randstrobe_implementations/src/index.cpp
@@ -151,7 +151,7 @@ void string_to_hash_xxhash(std::string &seq, std::vector<uint64_t> &string_hashe
         if (c < 4) { // not an "N" base
             x = (x << 2 | c) & kmask;                  // forward strand
             if (++l >= k) { // we find a k-mer
-                uint64_t hash_k = XXH3_64bits(&x, sizeof(uint64_t));
+                uint64_t hash_k = XXH3_64bits_withSeed(&x, sizeof(x), 0);
 //                (size_t) XXH3_128bits(src, srcSize).low64
                 string_hashes.push_back(hash_k);
                 pos_to_seq_choord.push_back( i - k + 1);
@@ -450,7 +450,7 @@ inline void get_next_strobe_liu_patro_li(std::vector<uint64_t> &string_hashes, u
     strobeconcat.high = strobe_hashval;
     for (auto i = w_start; i <= w_end; i++) {
         strobeconcat.low = string_hashes[i];
-        uint64_t res = XXH3_64bits_withSeed(&strobeconcat, sizeof(int128), 0);
+        uint64_t res = XXH3_64bits_withSeed(&strobeconcat, sizeof(strobeconcat), 0);
 
 
         if (res < min_val){

--- a/randstrobe_implementations/src/index.cpp
+++ b/randstrobe_implementations/src/index.cpp
@@ -10,7 +10,7 @@
 #include <math.h>       /* pow */
 #include <bitset>
 #include "xxhash.h"
-
+#include "wyhash.h"
 
 /**********************************************************
  *
@@ -35,6 +35,13 @@ uint64_t hash(std::string kmer)
  * hash kmer into uint64
  *
  * *******************************************************/
+//
+//
+//
+//
+//
+//
+//
 // copy from minimap2:sketch.c : Thomas Wang Hash
 static inline uint64_t hash64(uint64_t key, uint64_t mask)
 {
@@ -74,6 +81,7 @@ static inline uint64_t kmer_to_uint64(std::string &kmer, uint64_t kmask)
 
     for (char i : kmer) {
         int c = seq_nt4_table[(uint8_t)i];
+
         bkmer = (bkmer << 2 | c) & kmask;
 
     }
@@ -114,6 +122,7 @@ void string_to_hash_wang(std::string &seq, std::vector<uint64_t> &string_hashes,
     int i;
     uint64_t x = 0;
     for (int i = l = 0; i < seq.length(); i++) {
+
         int c = seq_nt4_table[(uint8_t) seq[i]];
         if (c < 4) { // not an "N" base
             x = (x << 2 | c) & kmask;                  // forward strand
@@ -142,7 +151,7 @@ void string_to_hash_xxhash(std::string &seq, std::vector<uint64_t> &string_hashe
         if (c < 4) { // not an "N" base
             x = (x << 2 | c) & kmask;                  // forward strand
             if (++l >= k) { // we find a k-mer
-                uint64_t hash_k = XXH64(&x, sizeof(uint64_t),0);
+                uint64_t hash_k = XXH3_64bits(&x, sizeof(uint64_t));
 //                (size_t) XXH3_128bits(src, srcSize).low64
                 string_hashes.push_back(hash_k);
                 pos_to_seq_choord.push_back( i - k + 1);
@@ -154,6 +163,7 @@ void string_to_hash_xxhash(std::string &seq, std::vector<uint64_t> &string_hashe
         }
     }
 }
+
 
 
 
@@ -194,6 +204,7 @@ mers_vector link_2_strobes_shen(int w_min, int w_max, std::vector<uint64_t> &str
         if (i + w_max <= seq_length - 1){
             unsigned int w_start = i+w_min;
             unsigned int w_end = i+w_max;
+
             uint64_t strobe_hash;
             strobe_hash = string_hashes[i];
             get_next_strobe_shen(string_hashes, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end, q);
@@ -234,6 +245,7 @@ inline void get_next_strobe_sahlin1(std::vector<uint64_t> &string_hashes, uint64
         if (res < min_val){
             min_val = res;
             strobe_pos_next = i;
+
             strobe_hashval_next = string_hashes[i];
         }
     }
@@ -274,6 +286,7 @@ mers_vector link_2_strobes_sahlin1(int w_min, int w_max, std::vector<uint64_t> &
         }
         else{
             return randstrobes2;
+
         }
 
 //        uint64_t hash_randstrobe2 = (string_hashes[i] << k) ^ strobe_hashval_next;
@@ -314,6 +327,7 @@ mers_vector link_2_strobes_sahlin2(int w_min, int w_max, std::vector<uint64_t> &
     if (string_hashes.size() == 0) {
         return randstrobes2;
     }
+    //
 //    std::cout << seq << std::endl;
     int seq_length = string_hashes.size();
     // create the randstrobes
@@ -354,6 +368,7 @@ mers_vector link_2_strobes_sahlin2(int w_min, int w_max, std::vector<uint64_t> &
 
 //        auto strobe1 = seq.substr(i, k);
 //        std::cout << std::string(i, ' ') << strobe1 << std::string(strobe_pos_next - (i+k), ' ') << std::string(k, 'X') << std::endl;
+
 
     }
     return randstrobes2;
@@ -394,6 +409,7 @@ mers_vector link_2_strobes_guo_pibri(int w_min, int w_max, std::vector<uint64_t>
         if (i + w_max <= seq_length - 1){
             unsigned int w_start = i+w_min;
             unsigned int w_end = i+w_max;
+
             uint64_t strobe_hash;
             strobe_hash = string_hashes[i];
             get_next_strobe_guo_pibri(string_hashes, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end);
@@ -429,11 +445,14 @@ mers_vector link_2_strobes_guo_pibri(int w_min, int w_max, std::vector<uint64_t>
 typedef struct { uint64_t high; uint64_t low; } int128;
 inline void get_next_strobe_liu_patro_li(std::vector<uint64_t> &string_hashes, uint64_t strobe_hashval, unsigned int &strobe_pos_next, uint64_t &strobe_hashval_next,  unsigned int w_start, unsigned int w_end){
     uint64_t min_val = UINT64_MAX;
+    uint64_t _wyp[4];
     int128 strobeconcat;
     strobeconcat.high = strobe_hashval;
     for (auto i = w_start; i <= w_end; i++) {
         strobeconcat.low = string_hashes[i];
-        uint64_t res = XXH64(&strobeconcat, sizeof(int128), 0);
+        uint64_t res = XXH3_64bits_withSeed(&strobeconcat, sizeof(int128), 0);
+
+
         if (res < min_val){
             min_val = res;
             strobe_pos_next = i;
@@ -441,6 +460,26 @@ inline void get_next_strobe_liu_patro_li(std::vector<uint64_t> &string_hashes, u
         }
     }
 }
+
+
+inline void get_next_strobe_liu_patro_li_wyhash(std::vector<uint64_t> &string_hashes, uint64_t strobe_hashval, unsigned int &strobe_pos_next, uint64_t &strobe_hashval_next,  unsigned int w_start, unsigned int w_end){
+    uint64_t min_val = UINT64_MAX;
+    uint64_t _wyp[4];
+    int128 strobeconcat;
+    strobeconcat.high = strobe_hashval;
+    for (auto i = w_start; i <= w_end; i++) {
+        strobeconcat.low = string_hashes[i];
+        uint64_t res = wyhash(&strobeconcat, sizeof(int128), 0, _wyp);
+
+
+        if (res < min_val){
+            min_val = res;
+            strobe_pos_next = i;
+            strobe_hashval_next = string_hashes[i];
+        }
+    }
+}
+
 
 mers_vector link_2_strobes_liu_patro_li(int w_min, int w_max, std::vector<uint64_t> &string_hashes, std::vector<unsigned int> &pos_to_seq_choord, unsigned int ref_index)
 {
@@ -455,6 +494,7 @@ mers_vector link_2_strobes_liu_patro_li(int w_min, int w_max, std::vector<uint64
     for (unsigned int i = 0; i <= seq_length; i++) {
 
 //        if ((i % 1000000) == 0 ){
+//
 //            std::cout << i << " strobemers created." << std::endl;
 //        }
         unsigned int strobe_pos_next;
@@ -473,6 +513,61 @@ mers_vector link_2_strobes_liu_patro_li(int w_min, int w_max, std::vector<uint64
             uint64_t strobe_hash;
             strobe_hash = string_hashes[i];
             get_next_strobe_liu_patro_li(string_hashes, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end);
+        }
+        else{
+            return randstrobes2;
+        }
+
+//        uint64_t hash_randstrobe2 = (string_hashes[i] << k) ^ strobe_hashval_next;
+        uint64_t hash_randstrobe2 = (string_hashes[i]/2) + (strobe_hashval_next/3);
+
+        unsigned int seq_pos_strobe1 = pos_to_seq_choord[i];
+        unsigned int seq_pos_strobe2 = pos_to_seq_choord[strobe_pos_next];
+        std::tuple<uint64_t, unsigned int, unsigned int, unsigned int, unsigned int> s (hash_randstrobe2, ref_index, seq_pos_strobe1, seq_pos_strobe2, seq_pos_strobe2);
+        randstrobes2.push_back(s);
+
+
+//        auto strobe1 = seq.substr(i, k);
+//        std::cout << std::string(i, ' ') << strobe1 << std::string(strobe_pos_next - (i+k), ' ') << std::string(k, 'X') << std::endl;
+
+    }
+    return randstrobes2;
+}
+
+
+
+mers_vector link_2_strobes_liu_patro_li_wyhash(int w_min, int w_max, std::vector<uint64_t> &string_hashes, std::vector<unsigned int> &pos_to_seq_choord, unsigned int ref_index)
+{
+    mers_vector randstrobes2;
+
+    if (string_hashes.size() == 0) {
+        return randstrobes2;
+    }
+//    std::cout << seq << std::endl;
+    int seq_length = string_hashes.size();
+    // create the randstrobes
+    for (unsigned int i = 0; i <= seq_length; i++) {
+
+//        if ((i % 1000000) == 0 ){
+//
+//            std::cout << i << " strobemers created." << std::endl;
+//        }
+        unsigned int strobe_pos_next;
+        uint64_t strobe_hashval_next;
+
+        if (i + w_max <= seq_length - 1){
+            unsigned int w_start = i+w_min;
+            unsigned int w_end = i+w_max;
+            uint64_t strobe_hash;
+            strobe_hash = string_hashes[i];
+            get_next_strobe_liu_patro_li_wyhash(string_hashes, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end);
+        }
+        else if ((i + w_min + 1 < seq_length) && (seq_length <= i + w_max) ){
+            unsigned int w_start = i+w_min;
+            unsigned int w_end = seq_length -1;
+            uint64_t strobe_hash;
+            strobe_hash = string_hashes[i];
+            get_next_strobe_liu_patro_li_wyhash(string_hashes, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end);
         }
         else{
             return randstrobes2;

--- a/randstrobe_implementations/src/index.hpp
+++ b/randstrobe_implementations/src/index.hpp
@@ -31,6 +31,8 @@ mers_vector link_2_strobes_shen(int w_min, int w_max, std::vector<uint64_t> &str
 mers_vector link_2_strobes_sahlin2(int w_min, int w_max, std::vector<uint64_t> &string_hashes, std::vector<unsigned int> &pos_to_seq_choord, unsigned int ref_index);
 mers_vector link_2_strobes_guo_pibri(int w_min, int w_max, std::vector<uint64_t> &string_hashes, std::vector<unsigned int> &pos_to_seq_choord, unsigned int ref_index);
 mers_vector link_2_strobes_liu_patro_li(int w_min, int w_max, std::vector<uint64_t> &string_hashes, std::vector<unsigned int> &pos_to_seq_choord, unsigned int ref_index);
+mers_vector link_2_strobes_liu_patro_li_wyhash(int w_min, int w_max, std::vector<uint64_t> &string_hashes, std::vector<unsigned int> &pos_to_seq_choord, unsigned int ref_index);
+
 
 
 mers_vector link_3_strobes_method2(int w_min, int w_max, std::vector<uint64_t> &string_hashes, std::vector<unsigned int> &pos_to_seq_choord, unsigned int ref_index);

--- a/randstrobe_implementations/src/main.cpp
+++ b/randstrobe_implementations/src/main.cpp
@@ -612,6 +612,24 @@ int main (int argc, char *argv[])
                 randstrobes2.clear();
                 pos_to_seq_choord.clear();
             }
+            if (link_func == 6) { // method 6 recuires combined link and hash
+                auto start_hash = std::chrono::high_resolution_clock::now();
+                string_to_hash_nohash(ref_seqs[i], string_hashes, pos_to_seq_choord, k);
+                auto end_hash = std::chrono::high_resolution_clock::now();
+                elapsed_hash += end_hash - start_hash;
+
+                auto start_link = std::chrono::high_resolution_clock::now();
+                randstrobes2 = link_2_strobes_liu_patro_li_wyhash(w_min, w_max, string_hashes, pos_to_seq_choord, i);
+                auto end_link = std::chrono::high_resolution_clock::now();
+                elapsed_link += end_link - start_link;
+                for (auto &t : randstrobes2) {
+                    flat_vector.push_back(t);
+                }
+                string_hashes.clear();
+                randstrobes2.clear();
+                pos_to_seq_choord.clear();
+            }
+ 
             else { // the other methods can be separated
                 auto start_hash = std::chrono::high_resolution_clock::now();
                 // first hash

--- a/randstrobe_implementations/src/main.cpp
+++ b/randstrobe_implementations/src/main.cpp
@@ -104,6 +104,8 @@ static inline void print_positions(mers_vector &flat_vector, idx_to_acc &acc_map
         l_method = "Guo-Pibri";
     } else if (link_func == 5){
         l_method = "Liu-Patro-Li";
+    } else if (link_func == 6){
+        l_method = "Liu-Patro-Li_wyhash";
     }
 
 
@@ -611,8 +613,7 @@ int main (int argc, char *argv[])
                 string_hashes.clear();
                 randstrobes2.clear();
                 pos_to_seq_choord.clear();
-            }
-            if (link_func == 6) { // method 6 recuires combined link and hash
+            } else if (link_func == 6) { // method 6 recuires combined link and hash
                 auto start_hash = std::chrono::high_resolution_clock::now();
                 string_to_hash_nohash(ref_seqs[i], string_hashes, pos_to_seq_choord, k);
                 auto end_hash = std::chrono::high_resolution_clock::now();
@@ -628,9 +629,7 @@ int main (int argc, char *argv[])
                 string_hashes.clear();
                 randstrobes2.clear();
                 pos_to_seq_choord.clear();
-            }
- 
-            else { // the other methods can be separated
+            } else { // the other methods can be separated
                 auto start_hash = std::chrono::high_resolution_clock::now();
                 // first hash
                 if (hash_func == 1) {

--- a/randstrobe_implementations/src/wyhash.h
+++ b/randstrobe_implementations/src/wyhash.h
@@ -1,0 +1,268 @@
+// This is free and unencumbered software released into the public domain under The Unlicense (http://unlicense.org/)
+// main repo: https://github.com/wangyi-fudan/wyhash
+// author: 王一 Wang Yi <godspeed_china@yeah.net>
+// contributors: Reini Urban, Dietrich Epp, Joshua Haberman, Tommy Ettinger, Daniel Lemire, Otmar Ertl, cocowalla, leo-yuriev, Diego Barrios Romero, paulie-g, dumblob, Yann Collet, ivte-ms, hyb, James Z.M. Gao, easyaspi314 (Devin), TheOneric
+
+/* quick example:
+   string s="fjsakfdsjkf";
+   uint64_t hash=wyhash(s.c_str(), s.size(), 0, _wyp);
+*/
+
+#ifndef wyhash_final_version_3
+#define wyhash_final_version_3
+
+#ifndef WYHASH_CONDOM
+//protections that produce different results:
+//1: normal valid behavior
+//2: extra protection against entropy loss (probability=2^-63), aka. "blind multiplication"
+#define WYHASH_CONDOM 1
+#endif
+
+#ifndef WYHASH_32BIT_MUM
+//0: normal version, slow on 32 bit systems
+//1: faster on 32 bit systems but produces different results, incompatible with wy2u0k function
+#define WYHASH_32BIT_MUM 0  
+#endif
+
+//includes
+#include <stdint.h>
+#include <string.h>
+#if defined(_MSC_VER) && defined(_M_X64)
+  #include <intrin.h>
+  #pragma intrinsic(_umul128)
+#endif
+
+//likely and unlikely macros
+#if defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__clang__)
+  #define _likely_(x)  __builtin_expect(x,1)
+  #define _unlikely_(x)  __builtin_expect(x,0)
+#else
+  #define _likely_(x) (x)
+  #define _unlikely_(x) (x)
+#endif
+
+//128bit multiply function
+static inline uint64_t _wyrot(uint64_t x) { return (x>>32)|(x<<32); }
+static inline void _wymum(uint64_t *A, uint64_t *B){
+#if(WYHASH_32BIT_MUM)
+  uint64_t hh=(*A>>32)*(*B>>32), hl=(*A>>32)*(uint32_t)*B, lh=(uint32_t)*A*(*B>>32), ll=(uint64_t)(uint32_t)*A*(uint32_t)*B;
+  #if(WYHASH_CONDOM>1)
+  *A^=_wyrot(hl)^hh; *B^=_wyrot(lh)^ll;
+  #else
+  *A=_wyrot(hl)^hh; *B=_wyrot(lh)^ll;
+  #endif
+#elif defined(__SIZEOF_INT128__)
+  __uint128_t r=*A; r*=*B; 
+  #if(WYHASH_CONDOM>1)
+  *A^=(uint64_t)r; *B^=(uint64_t)(r>>64);
+  #else
+  *A=(uint64_t)r; *B=(uint64_t)(r>>64);
+  #endif
+#elif defined(_MSC_VER) && defined(_M_X64)
+  #if(WYHASH_CONDOM>1)
+  uint64_t  a,  b;
+  a=_umul128(*A,*B,&b);
+  *A^=a;  *B^=b;
+  #else
+  *A=_umul128(*A,*B,B);
+  #endif
+#else
+  uint64_t ha=*A>>32, hb=*B>>32, la=(uint32_t)*A, lb=(uint32_t)*B, hi, lo;
+  uint64_t rh=ha*hb, rm0=ha*lb, rm1=hb*la, rl=la*lb, t=rl+(rm0<<32), c=t<rl;
+  lo=t+(rm1<<32); c+=lo<t; hi=rh+(rm0>>32)+(rm1>>32)+c;
+  #if(WYHASH_CONDOM>1)
+  *A^=lo;  *B^=hi;
+  #else
+  *A=lo;  *B=hi;
+  #endif
+#endif
+}
+
+//multiply and xor mix function, aka MUM
+static inline uint64_t _wymix(uint64_t A, uint64_t B){ _wymum(&A,&B); return A^B; }
+
+//endian macros
+#ifndef WYHASH_LITTLE_ENDIAN
+  #if defined(_WIN32) || defined(__LITTLE_ENDIAN__) || (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+    #define WYHASH_LITTLE_ENDIAN 1
+  #elif defined(__BIG_ENDIAN__) || (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+    #define WYHASH_LITTLE_ENDIAN 0
+  #else
+    #warning could not determine endianness! Falling back to little endian.
+    #define WYHASH_LITTLE_ENDIAN 1
+  #endif
+#endif
+
+//read functions
+#if (WYHASH_LITTLE_ENDIAN)
+static inline uint64_t _wyr8(const uint8_t *p) { uint64_t v; memcpy(&v, p, 8); return v;}
+static inline uint64_t _wyr4(const uint8_t *p) { uint32_t v; memcpy(&v, p, 4); return v;}
+#elif defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__clang__)
+static inline uint64_t _wyr8(const uint8_t *p) { uint64_t v; memcpy(&v, p, 8); return __builtin_bswap64(v);}
+static inline uint64_t _wyr4(const uint8_t *p) { uint32_t v; memcpy(&v, p, 4); return __builtin_bswap32(v);}
+#elif defined(_MSC_VER)
+static inline uint64_t _wyr8(const uint8_t *p) { uint64_t v; memcpy(&v, p, 8); return _byteswap_uint64(v);}
+static inline uint64_t _wyr4(const uint8_t *p) { uint32_t v; memcpy(&v, p, 4); return _byteswap_ulong(v);}
+#else
+static inline uint64_t _wyr8(const uint8_t *p) {
+  uint64_t v; memcpy(&v, p, 8);
+  return (((v >> 56) & 0xff)| ((v >> 40) & 0xff00)| ((v >> 24) & 0xff0000)| ((v >>  8) & 0xff000000)| ((v <<  8) & 0xff00000000)| ((v << 24) & 0xff0000000000)| ((v << 40) & 0xff000000000000)| ((v << 56) & 0xff00000000000000));
+}
+static inline uint64_t _wyr4(const uint8_t *p) {
+  uint32_t v; memcpy(&v, p, 4);
+  return (((v >> 24) & 0xff)| ((v >>  8) & 0xff00)| ((v <<  8) & 0xff0000)| ((v << 24) & 0xff000000));
+}
+#endif
+static inline uint64_t _wyr3(const uint8_t *p, size_t k) { return (((uint64_t)p[0])<<16)|(((uint64_t)p[k>>1])<<8)|p[k-1];}
+//wyhash main function
+static inline uint64_t wyhash(const void *key, size_t len, uint64_t seed, const uint64_t *secret){
+  const uint8_t *p=(const uint8_t *)key; seed^=*secret;	uint64_t	a,	b;
+  if(_likely_(len<=16)){
+    if(_likely_(len>=4)){ a=(_wyr4(p)<<32)|_wyr4(p+((len>>3)<<2)); b=(_wyr4(p+len-4)<<32)|_wyr4(p+len-4-((len>>3)<<2)); }
+    else if(_likely_(len>0)){ a=_wyr3(p,len); b=0;}
+    else a=b=0;
+  }
+  else{
+    size_t i=len; 
+    if(_unlikely_(i>48)){
+      uint64_t see1=seed, see2=seed;
+      do{
+        seed=_wymix(_wyr8(p)^secret[1],_wyr8(p+8)^seed);
+        see1=_wymix(_wyr8(p+16)^secret[2],_wyr8(p+24)^see1);
+        see2=_wymix(_wyr8(p+32)^secret[3],_wyr8(p+40)^see2);
+        p+=48; i-=48;
+      }while(_likely_(i>48));
+      seed^=see1^see2;
+    }
+    while(_unlikely_(i>16)){  seed=_wymix(_wyr8(p)^secret[1],_wyr8(p+8)^seed);  i-=16; p+=16;  }
+    a=_wyr8(p+i-16);  b=_wyr8(p+i-8);
+  }
+  return _wymix(secret[1]^len,_wymix(a^secret[1],b^seed));
+}
+
+//the default secret parameters
+static const uint64_t _wyp[4] = {0xa0761d6478bd642full, 0xe7037ed1a0b428dbull, 0x8ebc6af09c88c6e3ull, 0x589965cc75374cc3ull};
+
+//a useful 64bit-64bit mix function to produce deterministic pseudo random numbers that can pass BigCrush and PractRand
+static inline uint64_t wyhash64(uint64_t A, uint64_t B){ A^=0xa0761d6478bd642full; B^=0xe7037ed1a0b428dbull; _wymum(&A,&B); return _wymix(A^0xa0761d6478bd642full,B^0xe7037ed1a0b428dbull);}
+
+//The wyrand PRNG that pass BigCrush and PractRand
+static inline uint64_t wyrand(uint64_t *seed){ *seed+=0xa0761d6478bd642full; return _wymix(*seed,*seed^0xe7037ed1a0b428dbull);}
+
+//convert any 64 bit pseudo random numbers to uniform distribution [0,1). It can be combined with wyrand, wyhash64 or wyhash.
+static inline double wy2u01(uint64_t r){ const double _wynorm=1.0/(1ull<<52); return (r>>12)*_wynorm;}
+
+//convert any 64 bit pseudo random numbers to APPROXIMATE Gaussian distribution. It can be combined with wyrand, wyhash64 or wyhash.
+static inline double wy2gau(uint64_t r){ const double _wynorm=1.0/(1ull<<20); return ((r&0x1fffff)+((r>>21)&0x1fffff)+((r>>42)&0x1fffff))*_wynorm-3.0;}
+
+#if(!WYHASH_32BIT_MUM)
+//fast range integer random number generation on [0,k) credit to Daniel Lemire. May not work when WYHASH_32BIT_MUM=1. It can be combined with wyrand, wyhash64 or wyhash.
+static inline uint64_t wy2u0k(uint64_t r, uint64_t k){ _wymum(&r,&k); return k; }
+#endif
+
+//make your own secret
+static inline void make_secret(uint64_t seed, uint64_t *secret){
+  uint8_t c[] = {15, 23, 27, 29, 30, 39, 43, 45, 46, 51, 53, 54, 57, 58, 60, 71, 75, 77, 78, 83, 85, 86, 89, 90, 92, 99, 101, 102, 105, 106, 108, 113, 114, 116, 120, 135, 139, 141, 142, 147, 149, 150, 153, 154, 156, 163, 165, 166, 169, 170, 172, 177, 178, 180, 184, 195, 197, 198, 201, 202, 204, 209, 210, 212, 216, 225, 226, 228, 232, 240 };
+  for(size_t i=0;i<4;i++){
+    uint8_t ok;
+    do{
+      ok=1; secret[i]=0;
+      for(size_t j=0;j<64;j+=8) secret[i]|=((uint64_t)c[wyrand(&seed)%sizeof(c)])<<j;
+      if(secret[i]%2==0){ ok=0; continue; }
+      for(size_t j=0;j<i;j++) {
+#if defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__clang__)
+        if(__builtin_popcountll(secret[j]^secret[i])!=32){ ok=0; break; }
+#elif defined(_MSC_VER) && defined(_M_X64)
+        if(_mm_popcnt_u64(secret[j]^secret[i])!=32){ ok=0; break; }
+#else
+        //manual popcount
+        uint64_t x = secret[j]^secret[i];
+        x -= (x >> 1) & 0x5555555555555555;
+        x = (x & 0x3333333333333333) + ((x >> 2) & 0x3333333333333333);
+        x = (x + (x >> 4)) & 0x0f0f0f0f0f0f0f0f;
+        x = (x * 0x0101010101010101) >> 56;
+        if(x!=32){ ok=0; break; }
+#endif
+      }
+    }while(!ok);
+  }
+}
+
+/*  This is world's fastest hash map: 2x faster than bytell_hash_map.
+    It does not store the keys, but only the hash/signature of keys.
+    First we use pos=hash1(key) to approximately locate the bucket.
+    Then we search signature=hash2(key) from pos linearly.
+    If we find a bucket with matched signature we report the bucket
+    Or if we meet a bucket whose signature=0, we report a new position to insert
+    The signature collision probability is very low as we usually searched N~10 buckets.
+    By combining hash1 and hash2, we acturally have 128 bit anti-collision strength.
+    hash1 and hash2 can be the same function, resulting lower collision resistance but faster.
+    The signature is 64 bit, but can be modified to 32 bit if necessary for save space.
+    The above two can be activated by define WYHASHMAP_WEAK_SMALL_FAST
+    simple examples:
+    const	size_t	size=213432;
+    vector<wyhashmap_t>	idx(size);	//	allocate the index of fixed size. idx MUST be zeroed.
+    vector<value_class>	value(size);	//	we only care about the index, user should maintain his own value vectors.
+    string  key="dhskfhdsj"	//	the object to be inserted into idx
+    size_t	pos=wyhashmap(idx.data(), idx.size(), key.c_str(), key.size(), 1);	//	get the position and insert
+    if(pos<size)	value[pos]++;	//	we process the vallue
+    else	cerr<<"map is full\n";
+    pos=wyhashmap(idx.data(), idx.size(), key.c_str(), key.size(), 0);	// just lookup by setting insert=0
+    if(pos<size)	value[pos]++;	//	we process the vallue
+    else	cerr<<"the key does not exist\n";
+*/
+/*
+#ifdef	WYHASHMAP_WEAK_SMALL_FAST	// for small hashmaps whose size < 2^24 and acceptable collision
+typedef	uint32_t	wyhashmap_t;
+#else
+typedef	uint64_t	wyhashmap_t;
+#endif
+
+static	inline	size_t	wyhashmap(wyhashmap_t	*idx,	size_t	idx_size,	const	void *key, size_t	key_size,	uint8_t	insert, uint64_t *secret){
+	size_t	i=1;	uint64_t	h2;	wyhashmap_t	sig;
+	do{	sig=h2=wyhash(key,key_size,i,secret);	i++;	}while(_unlikely_(!sig));
+#ifdef	WYHASHMAP_WEAK_SMALL_FAST
+	size_t	i0=wy2u0k(h2,idx_size);
+#else
+	size_t	i0=wy2u0k(wyhash(key,key_size,0,secret),idx_size);
+#endif
+	for(i=i0;	i<idx_size&&idx[i]&&idx[i]!=sig;	i++);
+	if(_unlikely_(i==idx_size)){
+		for(i=0;	i<i0&&idx[i]&&idx[i]!=sig;  i++);
+		if(i==i0)	return	idx_size;
+	}
+	if(!idx[i]){
+		if(insert)	idx[i]=sig;
+		else	return	idx_size;
+	}
+	return	i;
+}
+*/
+#endif
+
+/* The Unlicense
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>
+*/


### PR DESCRIPTION
Hi @ksahlin,

  Since the concat method works (not necessarily equally well) with any hash, I added wyhash, which also passes all randomization benchmarks but is much faster than XXHash.  I also updated the XXH64 calls to XXH3 — since this is the newer and faster version of that hash function.

  Sorry for the code duplication; I did this while also trying to manage the kids eating breakfast ;P.

--Rob