### PR TITLE
Update usage string and doc to mention method 6

### DIFF
--- a/randstrobe_implementations/README.md
+++ b/randstrobe_implementations/README.md
@@ -19,6 +19,7 @@ Let the hash function be denoted by h.
 3. Sahlin bitcount( h(k_1) ^ h(k') ) 
 4. Guo-Pibri h(k_1) ^ h(k') (global XOR), (also a variant: h(k_1 ^ k'))
 5. Liu-Patro-Li h( k_1 || k' ) 
+6. Liu-Patro-Li h( k_1 || k' ) (using wyhash for linking)
 
 Viable combinations of (hashing, linking) seem to be (1,1)-(1,4), (2,1)-(2,4), (3,1)-(3,5) as the total length can be larger than 32.
 
@@ -52,7 +53,7 @@ g++-11 -std=c++14 main.cpp index.cpp xxhash.c -lz -fopenmp -o randstrobe_benchma
 Run
 
 ```
-./randstrobe_benchmark -x [1,2,3] -l [link method 1-5] refs.fasta queries.fasta
+./randstrobe_benchmark -x [1,2,3] -l [link method 1-6] refs.fasta queries.fasta
 ```
 
 If `-l 5` is specified, `-x` will use xxhash128.
@@ -70,7 +71,7 @@ options:
   -t INT number of threads [3]
   -o name of output tsv-file [output.tsv]
   -x Choice of hash function to use; 1: nohash, 2: Thomas Wang hash, 3:xxhash [1]. 
-  -l Choice of link function to use; 1: method1 (sahlin modulo), 2: method2 (shen bitwise AND), 3: method3 (guo_pibri XOR), 4: method4 (sahlin bitcount XOR), 5: method5 (Liu-Patro-Li, concatenation)
+  -l Choice of link function to use; 1: method1 (sahlin modulo), 2: method2 (shen bitwise AND), 3: method3 (guo_pibri XOR), 4: method4 (sahlin bitcount XOR), 5: method5 (Liu-Patro-Li, concatenation), 6: method6 (Liu-Patro-Li, concatenation using wyhash for linking).
 ```
 
 

--- a/randstrobe_implementations/src/main.cpp
+++ b/randstrobe_implementations/src/main.cpp
@@ -437,7 +437,7 @@ void print_usage() {
     std::cerr << "\t-t INT number of threads [3]\n";
     std::cerr << "\t-o name of output tsv-file [output.tsv]\n";
     std::cerr << "\t-x Choice of hash function to use; 1: nohash, 2: wanghash, 3:xxhash [1]. \n";
-    std::cerr << "\t-l Choice of link function to use; 1: method1 (sahlin modulo), 2: method2 (shen bitwise AND), 3: method3 (guo_pibri XOR), 4: method4 (sahlin bitcount XOR), 5: method5 (Liu-Patro-Li, concatenation). \n";
+    std::cerr << "\t-l Choice of link function to use; 1: method1 (sahlin modulo), 2: method2 (shen bitwise AND), 3: method3 (guo_pibri XOR), 4: method4 (sahlin bitcount XOR), 5: method5 (Liu-Patro-Li, concatenation), 6: method6 (Liu-Patro-Li, concatenation using wyhash for linking). \n";
 //    std::cerr << "\t-C UINT Mask (do not process) strobemer hits with count larger than C [1000]\n";
 //    std::cerr << "\t-L UINT Print at most L NAMs per query [1000]. Will print the NAMs with highest score S = n_strobemer_hits * query_span. \n";
 //    std::cerr << "\t-S Sort output NAMs for each query based on score. Default is to sort first by ref ID, then by query coordinate, then by reference coordinate. \n";


### PR DESCRIPTION
Of course, it may be better to break out the hash function used for linking as a separate parameter, but for now, this lists method 6 in the docs and usage string (same as method 5, but using wyhash for linking).